### PR TITLE
Workaround for ADF redirect after login

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -51,7 +51,7 @@ services:
     #environment:
     #  MIRROR_CONFIG: /app/server-map.json
     #volumes:
-    #  - /path/to/external/server-map.json:/app/Server-map.json
+    #  - ./files/Server-map.json:/app/Server-map.json
 
 volumes:
   adf_data:

--- a/files/Server-map.json
+++ b/files/Server-map.json
@@ -1,0 +1,45 @@
+{
+  "service": {
+    "comments": [
+      "Settings for the mirroring service itself.",
+      "control: where to authenticate PoolParty session and retrieve project uuid. @source is the source server.",
+      "name: optional; will be shown by the UI in the starting page",
+      "token: optional; alternative to session-based authentication",
+      "authorized_users: optional; if absent, any user can trigger synchronization",
+      "origins: optional list of CORS origins; omit if the UI is hosted on the source server",
+      "EXAMPLES:",
+      {
+        "name": "Taxonomy Publishing Service",
+        "token": "XXXXXXXXXXXXXXXXXXX",
+        "authorized_users": [
+          "sync_user",
+          "another_user"
+        ],
+        "origins": [
+          "https://mirroring-host.poolparty.biz"
+        ]
+      }
+    ],
+    "control": "@source"
+  },
+  "source": {
+    "host": "http://poolparty.127.0.0.1.nip.io",
+    "name": "Authoring",
+    "user": "apiuser",
+    "password": "poolparty",
+    "export_parameters": {
+      "modules": [ "concepts", "blacklistedTerms" ]
+    },
+    "comment": "Role: API User; Groups: Mirror"
+  },
+
+  "targets": [
+    {
+      "host": "https://my-prod.com",
+      "name": "Production",
+      "user": "apiadmin",
+      "password": "poolparty",
+      "comment": "Role: API Admin; Groups: Public"
+    }
+  ]
+}

--- a/files/nginx/addons/adf.conf
+++ b/files/nginx/addons/adf.conf
@@ -6,5 +6,6 @@ location /ADF {
     proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto  $scheme;
     proxy_set_header X-Forwarded-Host   $host;
-    proxy_set_header X-Forwarded-Port   $server_port;
+# For some reason ADF redirects to host:nginxPort after login, under investigation, this is a temp workaround
+#    proxy_set_header X-Forwarded-Port   $server_port;
 }


### PR DESCRIPTION
For some reason adf redirects to serverName:nginxPort/ADF after login, this is a workaround for the issue (exclude port) until it's checked and fixed inside the app