### PR TITLE
feat: update elasticsearch version to 9.3.3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       - --import-realm
 
   elasticsearch:
-    image: ontotext/poolparty-elasticsearch:9.2.4
+    image: ontotext/poolparty-elasticsearch:9.3.3
     environment:
       discovery.type:
       xpack.security.enabled:


### PR DESCRIPTION
Existing Elasticsearch deployments in Kubernetes with the official ECK operator cannot be upgraded from v8.19.x to v9.2.4 due to a know issue in Elasticsearch, see [Elasticsearch known issues | Elasticsearch Reference](https://www.elastic.co/docs/release-notes/elasticsearch/known-issues#elasticsearch-9.2.4-known-issues). This hinders the migration to 10.2 for our managed services or even clients that have this on premise.

The issue is fixed in Elasticsearch 9.2.5 which requires to build another container image for ES.

The workaround is to manually delete node shutdown status from ES, delete the pods and their volumes, find out affected/missing indices and then restore them from S3 (if not replicated) for all ES pods. This is very tedious, error prone and time consuming process.

Things done for issue is release of ES 9.2.5 and ES 9.3.3.