### PR TITLE
Split Keycloak public and internal URLs for ADF and Semantic Workbench

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -43,12 +43,7 @@ POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL="http://keycloak:8080/auth"
 POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL="${SERVER_URL}/auth"
 # Backward-compatible alias used by PoolParty (internal backchannel).
 POOLPARTY_KEYCLOAK_AUTHURL="${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
-# Note: addons.yaml also passes KEYCLOAK_URL (deprecated, same value as INTERNAL) alongside
-# KEYCLOAK_PUBLIC_URL and KEYCLOAK_INTERNAL_URL for older addon images during transition.
-# Semantic Workbench < 2.5.0 also relies on deprecated compose overrides for
-# spring.security.oauth2.client.provider.keycloak.authorization-uri and
-# spring.security.oauth2.resourceserver.jwt.issuer-uri in addons.yaml.
-# All deprecated compose settings are planned for removal.
+# addons.yaml also passes KEYCLOAK_URL (deprecated) alongside KEYCLOAK_PUBLIC_URL and KEYCLOAK_INTERNAL_URL.
 
 # Client id in the "poolparty" realm (POOLPARTY_KEYCLOAK_LOGIN_REALM). Used for retrieving access tokens.
 POOLPARTY_KEYCLOAK_LOGIN_CLIENTID=ppt

--- a/.env_template
+++ b/.env_template
@@ -37,8 +37,18 @@ POOLPARTY_KEYCLOAK_LOGIN_REALM=poolparty
 # Keycloak master realm.
 POOLPARTY_KEYCLOAK_ADMIN_REALM=master
 
-# Address to the Keycloak service, used by PoolParty to authenticate users.
-POOLPARTY_KEYCLOAK_AUTHURL="http://keycloak:8080/auth"
+# Internal Docker backchannel URL (server-to-server token/JWKS/introspection).
+POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL="http://keycloak:8080/auth"
+# Public browser-facing URL (via nginx proxy).
+POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL="${SERVER_URL}/auth"
+# Backward-compatible alias used by PoolParty (internal backchannel).
+POOLPARTY_KEYCLOAK_AUTHURL="${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
+# Note: addons.yaml also passes KEYCLOAK_URL (deprecated, same value as INTERNAL) alongside
+# KEYCLOAK_PUBLIC_URL and KEYCLOAK_INTERNAL_URL for older addon images during transition.
+# Semantic Workbench < 2.5.0 also relies on deprecated compose overrides for
+# spring.security.oauth2.client.provider.keycloak.authorization-uri and
+# spring.security.oauth2.resourceserver.jwt.issuer-uri in addons.yaml.
+# All deprecated compose settings are planned for removal.
 
 # Client id in the "poolparty" realm (POOLPARTY_KEYCLOAK_LOGIN_REALM). Used for retrieving access tokens.
 POOLPARTY_KEYCLOAK_LOGIN_CLIENTID=ppt

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ first login you'll be asked to change this password.
 * `POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL`: internal Docker URL for server-to-server Keycloak calls (default `http://keycloak:8080/auth`). Used by PoolParty and addon services for token/JWKS/introspection.
 * `POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL`: public browser-facing Keycloak URL (default `${SERVER_URL}/auth`). Used by ADF and Semantic Workbench for OAuth redirects.
 * `POOLPARTY_KEYCLOAK_AUTHURL`: backward-compatible alias for the internal URL, used by PoolParty.
-* `KEYCLOAK_URL` (in `addons.yaml` only, deprecated): alias of the internal URL, kept for older ADF/Semantic Workbench images. Prefer `POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL` and `POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL` instead.
-* `spring.security.oauth2.client.provider.keycloak.authorization-uri` and `spring.security.oauth2.resourceserver.jwt.issuer-uri` (in `addons.yaml` for Semantic Workbench only, deprecated): compose workaround for Semantic Workbench versions before 2.5.0. Redundant once the app reads `KEYCLOAK_PUBLIC_URL`. Both deprecated settings are planned for removal.
+* `KEYCLOAK_URL` (in `addons.yaml`, deprecated): alias of the internal URL for older ADF/Semantic Workbench images. Prefer `POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL` and `POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL`.
+* `spring.security.oauth2.client.provider.keycloak.authorization-uri` and `spring.security.oauth2.resourceserver.jwt.issuer-uri` (in `addons.yaml` for Semantic Workbench, deprecated): pre-existing compose workaround for Semantic Workbench versions before 2.5.0. Redundant on 2.5.0+ but kept for backward compatibility during transition.
 * `SERVER_NAME`: hostname used to access PoolParty from the browser (default `poolparty.127.0.0.1.nip.io`).
 
 Review the comments in the [.env_template](./.env_template) for all available variable and their purpose.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Other notable variable are:
 recommended to be changed in production environments.
 * `POOLPARTY_SUPER_ADMIN_PASSWORD`: this is the password for the `superadmin` in PoolParty, default `poolparty`. After the
 first login you'll be asked to change this password.
+* `POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL`: internal Docker URL for server-to-server Keycloak calls (default `http://keycloak:8080/auth`). Used by PoolParty and addon services for token/JWKS/introspection.
+* `POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL`: public browser-facing Keycloak URL (default `${SERVER_URL}/auth`). Used by ADF and Semantic Workbench for OAuth redirects.
+* `POOLPARTY_KEYCLOAK_AUTHURL`: backward-compatible alias for the internal URL, used by PoolParty.
+* `KEYCLOAK_URL` (in `addons.yaml` only, deprecated): alias of the internal URL, kept for older ADF/Semantic Workbench images. Prefer `POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL` and `POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL` instead.
+* `spring.security.oauth2.client.provider.keycloak.authorization-uri` and `spring.security.oauth2.resourceserver.jwt.issuer-uri` (in `addons.yaml` for Semantic Workbench only, deprecated): compose workaround for Semantic Workbench versions before 2.5.0. Redundant once the app reads `KEYCLOAK_PUBLIC_URL`. Both deprecated settings are planned for removal.
+* `SERVER_NAME`: hostname used to access PoolParty from the browser (default `poolparty.127.0.0.1.nip.io`).
 
 Review the comments in the [.env_template](./.env_template) for all available variable and their purpose.
 

--- a/addons.yaml
+++ b/addons.yaml
@@ -1,9 +1,14 @@
 services:
   adf:
+    # Requires ADF >= 1.9.0 for KEYCLOAK_PUBLIC_URL / KEYCLOAK_INTERNAL_URL support.
     image: ontotext/adf:1.8.2
     restart: unless-stopped
     environment:
-      KEYCLOAK_URL: "${POOLPARTY_KEYCLOAK_AUTHURL}"
+      KEYCLOAK_PUBLIC_URL: "${POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL}"
+      KEYCLOAK_INTERNAL_URL: "${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
+      # Deprecated: kept for older ADF images and custom overrides. Maps to internal URL.
+      # Planned for removal after two minor releases once ADF >= 1.9.0 is the minimum version.
+      KEYCLOAK_URL: "${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
       KEYCLOAK_REALM: "${POOLPARTY_KEYCLOAK_LOGIN_REALM}"
       POOLPARTY_URL: "${SERVER_URL}"
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_PPT_CLIENTSECRET: "${POOLPARTY_KEYCLOAK_LOGIN_CLIENTSECRET}"
@@ -14,13 +19,20 @@ services:
       - adf_data:/var/lib/adf
 
   semantic-workbench:
+    # Requires semantic-workbench >= 2.5.0 for KEYCLOAK_PUBLIC_URL / KEYCLOAK_INTERNAL_URL support.
     image: ontotext/semantic-workbench:2.4.2
     restart: unless-stopped
     environment:
-      spring.security.oauth2.client.provider.keycloak.authorization-uri: ${SERVER_URL}/auth/realms/poolparty/protocol/openid-connect/auth
-      spring.security.oauth2.resourceserver.jwt.issuer-uri: ${SERVER_URL}/auth/realms/poolparty
-      KEYCLOAK_URL: "${POOLPARTY_KEYCLOAK_AUTHURL}"
+      KEYCLOAK_PUBLIC_URL: "${POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL}"
+      KEYCLOAK_INTERNAL_URL: "${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
+      # Deprecated: kept for older Semantic Workbench images and custom overrides. Maps to internal URL.
+      # Planned for removal after two minor releases once semantic-workbench >= 2.5.0 is the minimum version.
+      KEYCLOAK_URL: "${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
       KEYCLOAK_REALM: "${POOLPARTY_KEYCLOAK_LOGIN_REALM}"
+      # Deprecated: compose workaround for Semantic Workbench < 2.5.0 (replaced by KEYCLOAK_PUBLIC_URL in the app).
+      # Redundant when using semantic-workbench >= 2.5.0. Planned for removal.
+      spring.security.oauth2.client.provider.keycloak.authorization-uri: ${SERVER_URL}/auth/realms/${POOLPARTY_KEYCLOAK_LOGIN_REALM}/protocol/openid-connect/auth
+      spring.security.oauth2.resourceserver.jwt.issuer-uri: ${SERVER_URL}/auth/realms/${POOLPARTY_KEYCLOAK_LOGIN_REALM}
       POOLPARTY_URL: "${SERVER_URL}"
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_PPT_CLIENTSECRET: "${POOLPARTY_KEYCLOAK_LOGIN_CLIENTSECRET}"
       POOLPARTY_LICENSE_PATH: "/usr/share/semantic-workbench"

--- a/addons.yaml
+++ b/addons.yaml
@@ -1,13 +1,11 @@
 services:
   adf:
-    # Requires ADF >= 1.9.0 for KEYCLOAK_PUBLIC_URL / KEYCLOAK_INTERNAL_URL support.
-    image: ontotext/adf:1.8.2
+    image: ontotext/adf:1.9.0
     restart: unless-stopped
     environment:
       KEYCLOAK_PUBLIC_URL: "${POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL}"
       KEYCLOAK_INTERNAL_URL: "${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
-      # Deprecated: kept for older ADF images and custom overrides. Maps to internal URL.
-      # Planned for removal after two minor releases once ADF >= 1.9.0 is the minimum version.
+      # Deprecated: maps to internal URL. Kept for older images and custom overrides.
       KEYCLOAK_URL: "${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
       KEYCLOAK_REALM: "${POOLPARTY_KEYCLOAK_LOGIN_REALM}"
       POOLPARTY_URL: "${SERVER_URL}"
@@ -19,26 +17,22 @@ services:
       - adf_data:/var/lib/adf
 
   semantic-workbench:
-    # Requires semantic-workbench >= 2.5.0 for KEYCLOAK_PUBLIC_URL / KEYCLOAK_INTERNAL_URL support.
-    image: ontotext/semantic-workbench:2.4.2
+    image: ontotext/semantic-workbench:2.5.0
     restart: unless-stopped
     environment:
       KEYCLOAK_PUBLIC_URL: "${POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL}"
       KEYCLOAK_INTERNAL_URL: "${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
-      # Deprecated: kept for older Semantic Workbench images and custom overrides. Maps to internal URL.
-      # Planned for removal after two minor releases once semantic-workbench >= 2.5.0 is the minimum version.
+      # Deprecated: maps to internal URL. Kept for older images and custom overrides.
       KEYCLOAK_URL: "${POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL}"
       KEYCLOAK_REALM: "${POOLPARTY_KEYCLOAK_LOGIN_REALM}"
-      # Deprecated: compose workaround for Semantic Workbench < 2.5.0 (replaced by KEYCLOAK_PUBLIC_URL in the app).
-      # Redundant when using semantic-workbench >= 2.5.0. Planned for removal.
+      # Deprecated: compose workaround for Semantic Workbench < 2.5.0 (pre-existing; kept during transition).
       spring.security.oauth2.client.provider.keycloak.authorization-uri: ${SERVER_URL}/auth/realms/${POOLPARTY_KEYCLOAK_LOGIN_REALM}/protocol/openid-connect/auth
       spring.security.oauth2.resourceserver.jwt.issuer-uri: ${SERVER_URL}/auth/realms/${POOLPARTY_KEYCLOAK_LOGIN_REALM}
       POOLPARTY_URL: "${SERVER_URL}"
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_PPT_CLIENTSECRET: "${POOLPARTY_KEYCLOAK_LOGIN_CLIENTSECRET}"
       POOLPARTY_LICENSE_PATH: "/usr/share/semantic-workbench"
       MANAGEMENT_ENDPOINTS_WEB_CORS_ALLOWED_ORIGINS: "${SERVER_URL}"
-      # todo: the app version should not be explicitly configured
-      APPLICATION_VERSION: "2.4.2"
+      APPLICATION_VERSION: "2.5.0"
     extra_hosts:
       - "${SERVER_NAME}:host-gateway"
     volumes:


### PR DESCRIPTION
Add POOLPARTY_KEYCLOAK_PUBLIC_AUTHURL and POOLPARTY_KEYCLOAK_INTERNAL_AUTHURL to .env_template, wire KEYCLOAK_PUBLIC_URL / KEYCLOAK_INTERNAL_URL in addons.yaml, and keep POOLPARTY_KEYCLOAK_AUTHURL as an internal alias for PoolParty. See the ADF & Semantic Workbench PRs under the same Issue ticker (GWP-2222) for the remaining changes.

Marking this as Draft until we merge the other subsequent changes which this PR depends on.