### PR TITLE
Updates the Mirror App image to the latest 2.5.0 version

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -44,7 +44,7 @@ services:
       - "${SERVER_NAME}:host-gateway"
 
   mirror-app:
-    image: ontotext/mirror-app:2.4.2
+    image: ontotext/mirror-app:2.5.0
     restart: unless-stopped
     ports:
       - "8008:8008"


### PR DESCRIPTION
- The new version contains couple of improvements and fixes.

  In addition the base image for the container was completely removed. The previous one has multiple security vulnerabilities. As bonus, the current image is smaller in size, compared to the previous one.