### PR TITLE
chore: Update GraphDB image to 11.4

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
     mem_limit: 10g
 
   graphdb:
-    image: ontotext/graphdb:11.3.2
+    image: ontotext/graphdb:11.4.0
     environment:
       USE_SYSTEM_CA_CERTS: yes
       graphdb__home: /opt/graphdb/home


### PR DESCRIPTION
Update the GraphDB image version to 11.4 in the compose-files repository and verify that the compose deployment works as expected.

Acceptance Criteria

GraphDB image version is updated to 11.4.

Compose deployment completes successfully.