### PR TITLE
fix: Graph Modeling closed absolute redirection setting in proxy

### DIFF
--- a/files/nginx/proxy.conf
+++ b/files/nginx/proxy.conf
@@ -1,6 +1,7 @@
 server {
     listen 80;
     server_name ${SERVER_NAME};
+    absolute_redirect off;
 
     client_max_body_size ${PROXY_CLIENT_MAX_BODY_SIZE};
     proxy_send_timeout ${PROXY_SEND_TIMEOUT};

--- a/files/nginx/proxy_ssl.conf
+++ b/files/nginx/proxy_ssl.conf
@@ -7,6 +7,7 @@ server {
 server {
     listen 443 ssl;
     server_name ${SERVER_NAME};
+    absolute_redirect off;
 
     client_max_body_size ${PROXY_CLIENT_MAX_BODY_SIZE};
     proxy_send_timeout ${PROXY_SEND_TIMEOUT};


### PR DESCRIPTION
**LOGIN**

Standard Graph Modeling URL is not functional anymore

`https://$URL/PoolParty
`
Login page is accessible, and after the timeout URL is routed to

`https://$URL:8443/PoolParty/
`
Its fix for those navigation problems 
