### PR TITLE
Fix UnifiedViews proxy redirects

### DIFF
--- a/files/nginx/addons/unifiedviews.conf
+++ b/files/nginx/addons/unifiedviews.conf
@@ -1,5 +1,19 @@
+location = /unifiedviews {
+    return 301 /UnifiedViews/;
+}
+
+location /unifiedviews/ {
+    rewrite ^/unifiedviews/(.*)$ /UnifiedViews/$1 permanent;
+}
+
+location = /UnifiedViews {
+    return 301 /UnifiedViews/;
+}
+
 location /UnifiedViews {
     proxy_pass http://unified-views:8080/UnifiedViews;
+
+    proxy_redirect http://$host/ https://$host/;
 
     proxy_set_header Host               $host;
     proxy_set_header X-Real-IP          $remote_addr;

--- a/files/nginx/addons/unifiedviews.conf
+++ b/files/nginx/addons/unifiedviews.conf
@@ -1,19 +1,16 @@
 location = /unifiedviews {
-    return 301 /UnifiedViews/;
+    return 301 /UnifiedViews/$is_args$args;
 }
 
 location /unifiedviews/ {
     rewrite ^/unifiedviews/(.*)$ /UnifiedViews/$1 permanent;
 }
 
-location = /UnifiedViews {
-    return 301 /UnifiedViews/;
-}
-
 location /UnifiedViews {
     proxy_pass http://unified-views:8080/UnifiedViews;
 
-    proxy_redirect http://$host/ https://$host/;
+    proxy_redirect http://unified-views:8080/UnifiedViews/ /UnifiedViews/;
+    proxy_redirect http://$host/ $scheme://$host/;
 
     proxy_set_header Host               $host;
     proxy_set_header X-Real-IP          $remote_addr;
@@ -25,6 +22,8 @@ location /UnifiedViews {
 
 location /master/ {
     proxy_pass http://unified-views:8080/master/;
+
+    proxy_redirect http://unified-views:8080/master/ /master/;
 
     proxy_set_header Host               $host;
     proxy_set_header X-Real-IP          $remote_addr;


### PR DESCRIPTION
This PR updates the UnifiedViews nginx proxy configuration.

Changes include:

- Redirect lowercase `/unifiedviews` requests to the canonical `/UnifiedViews/` path.
- Preserve subpaths when redirecting lowercase `/unifiedviews/...` URLs.
- Add an exact `/UnifiedViews` redirect to `/UnifiedViews/` so nginx handles the trailing slash.
- Keep `/UnifiedViews/` proxied to the Tomcat context from `UnifiedViews.war`.
- Add `proxy_redirect` to rewrite upstream `http://` redirects from UnifiedViews to `https://`.

This ensures UnifiedViews is always accessed through the correct case-sensitive context path and avoids mixed HTTP/HTTPS redirects during OIDC login.