### PR TITLE
GWP 2814 - Fix UnifiedViews proxy redirects

### DIFF
--- a/files/nginx/addons/unifiedviews.conf
+++ b/files/nginx/addons/unifiedviews.conf
@@ -1,5 +1,19 @@
+location = /unifiedviews {
+    return 301 /UnifiedViews/;
+}
+
+location /unifiedviews/ {
+    rewrite ^/unifiedviews/(.*)$ /UnifiedViews/$1 permanent;
+}
+
+location = /UnifiedViews {
+    return 301 /UnifiedViews/;
+}
+
 location /UnifiedViews {
     proxy_pass http://unified-views:8080/UnifiedViews;
+
+    proxy_redirect http://$host/ https://$host/;
 
     proxy_set_header Host               $host;
     proxy_set_header X-Real-IP          $remote_addr;

--- a/files/nginx/addons/unifiedviews.conf
+++ b/files/nginx/addons/unifiedviews.conf
@@ -1,19 +1,16 @@
 location = /unifiedviews {
-    return 301 /UnifiedViews/;
+    return 301 /UnifiedViews/$is_args$args;
 }
 
 location /unifiedviews/ {
     rewrite ^/unifiedviews/(.*)$ /UnifiedViews/$1 permanent;
 }
 
-location = /UnifiedViews {
-    return 301 /UnifiedViews/;
-}
-
 location /UnifiedViews {
     proxy_pass http://unified-views:8080/UnifiedViews;
 
-    proxy_redirect http://$host/ https://$host/;
+    proxy_redirect http://unified-views:8080/UnifiedViews/ /UnifiedViews/;
+    proxy_redirect http://$host/ $scheme://$host/;
 
     proxy_set_header Host               $host;
     proxy_set_header X-Real-IP          $remote_addr;
@@ -25,6 +22,8 @@ location /UnifiedViews {
 
 location /master/ {
     proxy_pass http://unified-views:8080/master/;
+
+    proxy_redirect http://unified-views:8080/master/ /master/;
 
     proxy_set_header Host               $host;
     proxy_set_header X-Real-IP          $remote_addr;


### PR DESCRIPTION
fix(nginx): handle UnifiedViews proxy redirects

- rely on the backend for the /UnifiedViews trailing slash
- preserve the request scheme in host redirects
- rewrite internal /master/ redirects to the public path